### PR TITLE
Adds wizards for dumping markdown and previewing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ js/vue.js
 js/jsoneditor.js
 test/
 test.html
+
+# Vim
+.*.swp

--- a/openapi-gui.js
+++ b/openapi-gui.js
@@ -6,9 +6,14 @@ const util = require('util');
 
 const express = require('express');
 const compression = require('compression');
+const widdershins = require('widdershins');
+const shins = require('shins');
 
 const ourVersion = require('./package.json').version;
 var definition = {openapi:"3.0.0",info:{title:"API",version:"1.0.0"}};
+
+// nice stack traces
+process.on('unhandledRejection', r => console.log(r));
 
 var api = require('openapi-webconverter/api.js').api;
 var app = api.app;
@@ -30,6 +35,48 @@ app.post('/store', upload.single('filename'), function(req, res) {
 app.get('/serve', function(req, res) {
     res.set('Content-Type','application/json');
     res.send(JSON.stringify(definition,null,2));
+});
+
+const getWiddershinsOptions = function() {
+	var options = {}; // defaults shown
+	options.codeSamples = true;
+	//options.language_tabs = [];
+	////options.loadedFrom = sourceUrl;
+	////options.user_templates = './user_templates';
+	options.templateCallback = function(templateName,stage,data) { return data };
+	options.theme = 'ocean';
+	options.search = true;
+	options.sample = true; // set false by --raw
+	options.schema = true; // set false by --noschema
+	options.discovery = false;
+	options.includes = [];
+	options.aggressive = false;
+	options.language_tabs = [{ 'http': 'HTTP' }, { 'javascript': 'JavaScript' }, { 'javascript--nodejs': 'Node.JS' }, { 'python': 'Python' }];
+	return options;
+}
+
+const getShinsOptions = function() {
+	var options = {};
+	options.minify = false;
+	options.customCss = false;
+	options.inline = false;
+	return options;
+}
+
+app.get('/markdown', function(req, res) {
+	widdershins.convert(definition, getWiddershinsOptions(), function(err,str){
+		res.set('Content-Type', 'text/plain');
+		res.send(str);
+	});
+});
+
+app.get('/shins', function(req, res) {
+	widdershins.convert(definition, getWiddershinsOptions(), function(err,str){
+		shins.render(str, getShinsOptions(), function(err, html) {
+			res.set('Content-Type', 'text/html');
+			res.send(html);
+		});
+	});
 });
 
 app.get('/', function (req, res) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "optionalDependencies": {
         "express": "^4.15.5",
         "compression": "^1.6.2",
-        "ejs": "^2.5.1"
+        "ejs": "^2.5.1",
+        "widdershins": "^2.2.5",
+		"shins": "^2.0.1-5"
     },
     "dependencies": {
         "openapi-webconverter": "^1.3.2"

--- a/src/app/gui.html
+++ b/src/app/gui.html
@@ -719,6 +719,9 @@
 					<ul>
 						<li><a id="aValidate">Validate definition</a> using <span v-if="!window.intelligentBackend"><a href="http://openapi-converter.herokuapp.com/">OpenAPI-converter</a> (online version of <a href="https://github.com/mermade/swagger2openapi">swagger2openapi</a>)</span><span v-if="window.intelligentBackend">built-in validator</span></li>
 						<li><a id="aShinola">Generate documentation</a> using <a href="https://github.com/mermade/shinola">shinola</a> (online <a href="https://github.com/mermade/widdershins">widdershins</a> and <a href="https://github.com/mermade/shins">shins</a> pipeline)</li>
+						<li v-if="window.intelligentBackend"><a id="aShins" href="/shins">Preview documentation</a> using <a href="https://github.com/mermade/widdershins">widdershins</a> and <a href="https://github.com/mermade/shins">shins</a> </li>
+						<li v-if="window.intelligentBackend"><a id="aWiddershins" href="/markdown">Dump markdown</a> using <a href="https://github.com/mermade/widdershins">widdershins</a> </li>
+
 						<li><a id="aCRUD">Create CRUD operations</a> from definition</li>
 						<li><a id="aImportSchema">Import schema</a></li>
 						<li>Create server SDK - {{cgData.servers.length}} languages - <a href="https://github.com/swagger-api/swagger-codegen/issues/4669">waiting for swagger-codegen</a></li>


### PR DESCRIPTION
This PR adds wizards for dumping markdown (via `widdershins`) and previewing documentation (via `shins`) in the *laziest way possible*.  I don't regularly author NodeJS apps, so I pretty much just mashed keys until it worked.

### Unfortunate Dependencies

~This PR is derived from my other PR that adds Docker support which most likely means you won't want to adopt it as-is.~  Not any more!

### Usage

1. Load the site in a browser.
2. Click "save" if you've never done that before to initialize your localStorage with the example.
3. Open the "Wizards" tab.
4. Click "Dump Markdown" to get the markdown, or `curl http://localhost:3000/markdown`.
5. Click "Preview Documentation" to see the docs, or navigate to `http://localhost:3000/shins`.

### Holy Smokes

It's clear you're putting a lot of effort into this project, and this low-effort hackjob really doesn't clear that bar.  I was _floored_ to discover both Widdershins, and Shins, and thought, "damn, this all needs to be integrated ASAP."