### PR TITLE
replace dubnium-alpine with 18-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:dubnium-alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
During build stage with base image dubnium-alpine error appears
```
yaml/dist/compose/composer.js:33
                if (prelude[i + 1]?.[0] !== '#')
                                   ^

SyntaxError: Unexpected token .
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (node_modules/yaml/dist/index.js:3:16)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
```
18-alpine image fix this problem